### PR TITLE
Dropped support for Debian Jessie

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Requirements
 
         * Debian
 
-            * Jessie (8)
             * Stretch (9)
             * Buster (10)
             * Bullseye (11)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,7 +19,6 @@ galaxy_info:
         - bionic
     - name: Debian
       versions:
-        - jessie
         - stretch
         - buster
         - bullseye

--- a/molecule/debian_min/molecule.yml
+++ b/molecule/debian_min/molecule.yml
@@ -13,7 +13,7 @@ lint: |
 
 platforms:
   - name: ansible_role_git_user_debian_min
-    image: debian:8
+    image: debian:9
     dockerfile: ../default/Dockerfile.j2
 
 provisioner:


### PR DESCRIPTION
Debian ended LTS support in June 2020.